### PR TITLE
Fixed output formatting bug 

### DIFF
--- a/src/spins/promela/compiler/ltsmin/LTSminPrinter.java
+++ b/src/spins/promela/compiler/ltsmin/LTSminPrinter.java
@@ -1826,13 +1826,16 @@ public class LTSminPrinter {
 			generateMaybe(w, id.getArrayExpr(), state);	
 			generateMaybe(w, id.getSub(), state);	
 			if (id.getArrayExpr() != null) {
-				w.append(" || ");
+				if (w.options.total) {
+					w.append(" || ");
+				}
+
 				generateExpression(w, id.getArrayExpr(), state);
 				w.append(" < 0 || ");
 				generateExpression(w, id.getArrayExpr(), state);
 				w.append(String.format(" >= %d", id.getVariable().getArraySize()));
 			} else if (id.getVariable().getArrayIndex() != -1) {
-				w.append(String.format(" || %s < 0 || %s >= %d", id.getVariable().getArrayIndex(), id.getVariable().getArrayIndex(), id.getVariable().getArraySize()));				
+				w.append(String.format(" || %s < 0 || %s >= %d", id.getVariable().getArrayIndex(), id.getVariable().getArrayIndex(), id.getVariable().getArraySize()));
 			}
 		} else if (e instanceof AritmicExpression) {
 			AritmicExpression ae = (AritmicExpression) e;
@@ -2090,7 +2093,11 @@ public class LTSminPrinter {
 		String maybe = w2.toString();
 
 		if (maybe.length() != 0) {
-			w.append("(0");
+			if (w.options.total) {
+				w.append("(0");
+			} else {
+				w.append("(");
+			}
 			w.append(maybe);
 			w.append(") ? 2 :").appendLine();
 			w.appendPrefix().appendPrefix().appendPrefix();

--- a/src/spins/promela/compiler/ltsmin/LTSminPrinter.java
+++ b/src/spins/promela/compiler/ltsmin/LTSminPrinter.java
@@ -1819,16 +1819,13 @@ public class LTSminPrinter {
 
 	private static int generateMaybe(StringWriter w, Expression e, LTSminPointer state) {
 		if (e == null) return 0;
-		
 		if (e instanceof LTSminIdentifier) {
 		} else if (e instanceof Identifier) {
 			Identifier id = (Identifier) e;
-			generateMaybe(w, id.getArrayExpr(), state);	
+			generateMaybe(w, id.getArrayExpr(), state);
 			generateMaybe(w, id.getSub(), state);	
 			if (id.getArrayExpr() != null) {
-				if (w.options.total) {
-					w.append(" || ");
-				}
+				w.append(" || ");
 
 				generateExpression(w, id.getArrayExpr(), state);
 				w.append(" < 0 || ");
@@ -2097,6 +2094,7 @@ public class LTSminPrinter {
 				w.append("(0");
 			} else {
 				w.append("(");
+				maybe = maybe.replaceFirst(" \\|\\|", "");
 			}
 			w.append(maybe);
 			w.append(") ? 2 :").appendLine();
@@ -2110,6 +2108,7 @@ public class LTSminPrinter {
 	private static void generateBoundsChecks(StringWriter w, LTSminModel model, Expression e) {
 		StringWriter w2 = new StringWriter(w.options);
 		generateMaybe(w2, e, out(model));
+
 		if (w2.length() > 0) {
 			if (w.options.total) {
 				w.appendPrefix();
@@ -2117,7 +2116,7 @@ public class LTSminPrinter {
 				w.appendPostfix();
 			} else {
 				w.appendPrefix();
-				w.append("assert( !("+ w2.toString() +") );");
+				w.append("assert( !("+ w2.toString().replaceFirst(" \\|\\|", "") +") );");
 			    w.appendPostfix();
 			}
 		}


### PR DESCRIPTION
models compiled without -T would get syntax errors in assertions.
This also removes "0 || " from the label evaluation expressions.